### PR TITLE
Fix Bar component's propTypes of 'fill' from string to arrayOf(string)

### DIFF
--- a/source/components/Bar.jsx
+++ b/source/components/Bar.jsx
@@ -6,7 +6,7 @@ export default class Bar extends React.Component {
   static propTypes = {
     values: React.PropTypes.any.isRequired,
     delimiter: React.PropTypes.string,
-    fill: React.PropTypes.string,
+    fill: React.PropTypes.arrayOf(React.PropTypes.string),
     height: React.PropTypes.number,
     min: React.PropTypes.number,
     max: React.PropTypes.number,


### PR DESCRIPTION
I fixed propType of Bar's property **fill** from string to arrayOf(string).
